### PR TITLE
Feature/fix lower case bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue-evm-nft",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vue-evm-nft",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "ISC",
       "dependencies": {
         "vue-tsc": "^2.1.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-evm-nft",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "src/index.js",
   "types": "src/types/index.d.ts",
   "scripts": {

--- a/src/composables/useEvmNft.js
+++ b/src/composables/useEvmNft.js
@@ -40,9 +40,10 @@ export async function useEvmNft(
   // Only initialize the contract if both contractAddress and contractABI are provided
   if (contractAddress && contractABI && provider) {
     contract = new ethers.Contract(contractAddress, contractABI, provider);
-    contractOwnerPublicKey = contractOwnerPublicKey.toLowerCase();
-    contractAddress = contractAddress.toLowerCase();
   }
+
+  contractOwnerPublicKey = contractOwnerPublicKey.toLowerCase();
+  contractAddress = contractAddress.toLowerCase();
 
   const loadingMessage = ref('');
 


### PR DESCRIPTION
The paramscontractAddress and contractOwnerPublicKey were not transformed to lowercase unless the contract was initialized. So this bug is the result of a performance enhancement for useEvmNft.getMetaDataToken.